### PR TITLE
Support multiple inverters and bugfixing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,7 +47,7 @@
 	"forwardPorts": [10004, 5050],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip3 install --user -r requirements.txt && pip3 install --user appdaemon && ln -s ../.omnik/config.yaml /workspaces/omnikdatalogger/apps/apps.yaml",
+	"postCreateCommand": "pip3 install --user -r requirements.txt && pip3 install --user appdaemon && ln -s -f ../.omnik/config.yaml /workspaces/omnikdatalogger/apps/apps.yaml",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,8 +15,13 @@
 	},
 
 	// Set *default* container specific settings.json values on container create.
-	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/bash",
+	"settings": {
+		"terminal.integrated.profiles.linux": {
+			"zsh (login)": {
+			  "path": "zsh",
+			  "args": ["-l"]
+			}
+		  } ,
 		"python.pythonPath": "/usr/local/bin/python",
 		"python.languageServer": "Pylance",
 		"python.linting.enabled": true,

--- a/apps/omnikdatalogger/omnik/datalogger.py
+++ b/apps/omnikdatalogger/omnik/datalogger.py
@@ -404,12 +404,16 @@ class DataLogger(object):
         newreporttime = datetime.fromtimestamp(data['last_update']).astimezone(timezone.utc)
         if not plant:
             plant = data['plant_id']
+        if plant == '0':
+            updated_entities = 'aggregated logging'
+        else:
+            updated_entities = f'plant {plant}'
         if netdata:
             hybridlogger.ha_log(self.logger, self.hass_api, "INFO",
-                                f"Net data update for plant '{plant}' update at UTC {newreporttime}")
+                                f"Net data update for {updated_entities} UTC {newreporttime}")
         else:
             hybridlogger.ha_log(self.logger, self.hass_api, "INFO",
-                                f"Update for plant {plant} update at UTC {newreporttime}")
+                                f"Update for {updated_entities} UTC {newreporttime}")
 
         return plant
 
@@ -428,7 +432,7 @@ class DataLogger(object):
                 # Only proces updates that occured after we started or start a single measurement (TODO)
                 if (newreporttime > self.plant_update[plant].last_update_time or not self.every or self.sundown):
                     hybridlogger.ha_log(self.logger, self.hass_api, "INFO",
-                                        f"Update for plant {plant} update at UTC {newreporttime}")
+                                        f"Update for plant {plant} UTC {newreporttime}")
                     # the newest plant_update time will be used as a baseline to program the timer
                     self.last_update_time = newreporttime
                     # Store the plant_update time for each indiviual plant,
@@ -708,7 +712,7 @@ class DataLogger(object):
             # set next time block for update
             self.pasttime = dsmr_timestamp - (dsmr_timestamp % self.interval_aggregated) + self.interval_aggregated
             # set net updates out for aggegated output (pvoutput) with (multiple) pushing inverters with aggegation and no updates
-            last_update = 0.0
+            last_update = time.time()
             if plant_id == '0':
                 for plant in self.plant_update:
                     if datetime.timestamp(self.plant_update[plant].last_update_time) > last_update:

--- a/apps/omnikdatalogger/omnik/datalogger.py
+++ b/apps/omnikdatalogger/omnik/datalogger.py
@@ -709,7 +709,7 @@ class DataLogger(object):
 
             aggegated_data = {}
             self._aggregate_data(aggegated_data, data)
-            # Do not publish the current power
+            # Do not publish the current power, since we do not know the last state
             # set next time block for update
             self.pasttime = dsmr_timestamp - (dsmr_timestamp % self.interval_aggregated) + self.interval_aggregated
             # set net updates out for aggegated output (pvoutput) with (multiple) pushing inverters with aggegation and no updates
@@ -720,7 +720,7 @@ class DataLogger(object):
                         last_update = datetime.timestamp(self.plant_update[plant].last_update_time)
             else:
                 last_update = datetime.timestamp(self.plant_update[plant_id].last_update_time)
-            if (dsmr_timestamp - last_update) > (self.every + 10) or self.last_current_power(plant_id):
+            if (dsmr_timestamp - last_update) > self.every + 10:
                 self._process_received_update(aggegated_data, netdata=True, plant=plant_id)
                 self._output_update_aggregated_data(plant_id, aggegated_data)
         # TODO process net update for other clients

--- a/apps/omnikdatalogger/omnik/datalogger.py
+++ b/apps/omnikdatalogger/omnik/datalogger.py
@@ -706,13 +706,14 @@ class DataLogger(object):
             data['today_energy'] = self.total_energy(plant_id, lifetime=False)
             self._calculate_consumption(data)
             data['total_energy'] = data.pop('total_energy_recalc')
+
             aggegated_data = {}
             self._aggregate_data(aggegated_data, data)
             # Do not publish the current power
             # set next time block for update
             self.pasttime = dsmr_timestamp - (dsmr_timestamp % self.interval_aggregated) + self.interval_aggregated
             # set net updates out for aggegated output (pvoutput) with (multiple) pushing inverters with aggegation and no updates
-            last_update = time.time()
+            last_update = 0.0
             if plant_id == '0':
                 for plant in self.plant_update:
                     if datetime.timestamp(self.plant_update[plant].last_update_time) > last_update:

--- a/apps/omnikdatalogger/omnik/dsmr/__init__.py
+++ b/apps/omnikdatalogger/omnik/dsmr/__init__.py
@@ -56,12 +56,6 @@ class DSRM(object):
             self.ts_last_telegram[terminal] = 0
             self.last_gas_update[terminal] = [0, Decimal('0.0'), Decimal('0.000')]
 
-            # Warnings and errors
-            if not self.tconfig[terminal]['plant_id']:
-                hybridlogger.ha_log(self.logger, self.hass_api,
-                                    "WARNING", f"DSMR 'plant_id' for terminal '{terminal}' is not specified. "
-                                    "Received data will be NOT be associated with your solar data "
-                                    "and will be processed as stand-a-lone data!")
             # Initialize terminal
             self.terminals[terminal] = Terminal(self.config, self.logger, self.hass_api, terminal,
                                                 self.dsmr_serial_callback, self.tconfig[terminal]['dsmr_version'])

--- a/apps/omnikdatalogger/omnik/dsmr/terminal.py
+++ b/apps/omnikdatalogger/omnik/dsmr/terminal.py
@@ -80,9 +80,9 @@ class Terminal(object):
         try:
             parsed_telegram = self.telegram_parser.parse(telegram)
         except InvalidChecksumError as e:
-            self.log.warning(str(e))
+            self.logger.warning(str(e))
         except ParseError:
-            self.log.exception("failed to parse telegram")
+            self.logger.exception("failed to parse telegram")
         else:
             self.dsmr_serial_callback(parsed_telegram)
 

--- a/apps/omnikdatalogger/omnik/plant.py
+++ b/apps/omnikdatalogger/omnik/plant.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timezone, time
+from decimal import Decimal
+
+
+class Plant():
+
+    def __init__(self, plant_id = None, last_update_time = None, *args, **kwargs):
+        self._plant_id = plant_id
+        self._last_update_time = last_update_time if last_update_time else datetime.now(timezone.utc)
+        self._updated = bool(last_update_time)
+        self._data = None
+
+    def plant_id(self):
+        return self._plant_id
+
+    def pop_for_aggregate(self, cache):
+        data_age = (datetime.now(timezone.utc) - self._last_update_time).seconds
+        if data_age > 360:
+            # data is too old discard, use cache
+            self._updated = False
+            # return True to ensure publising 
+            if not self._data:
+                self._data = {}
+            try:
+                self._data['total_energy'] = cache[f"{self._plant_id}.last_total_energy"]
+                self._data['today_energy'] = cache[f"{self._plant_id}.last_today_energy"]
+                self._data['current_power'] = Decimal('0.0')
+                self._data['last_update'] = time.time()
+            except:
+                return False
+            return True
+        if self._updated:
+            self._updated = False
+            return True
+        else:
+            # Data still valid, wait until all inverters showed their data
+            return False
+
+    @property
+    def last_update_time(self):
+        return self._last_update_time
+
+    @last_update_time.setter
+    def last_update_time(self, last_update_time):
+        self._last_update_time = last_update_time
+        self._updated = True
+
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, data):
+        self._data = data
+        self._updated = True

--- a/apps/omnikdatalogger/omnik/plugin_client/__init__.py
+++ b/apps/omnikdatalogger/omnik/plugin_client/__init__.py
@@ -6,7 +6,7 @@ class BaseClient(type):
         else:
             cls.register(cls)  # Called when a client class is imported
 
-    def register(cls, client):
+    def register(cls, client=None):
         cls.client.append(client())
 
 
@@ -16,6 +16,7 @@ class Client(object, metaclass=BaseClient):
     logger = None
     hass_api = None
     use_timer = True
+    plant_id_list = []
 
     def initialize(self):
         pass

--- a/apps/omnikdatalogger/omnik/plugin_client/solarmanpv.py
+++ b/apps/omnikdatalogger/omnik/plugin_client/solarmanpv.py
@@ -23,6 +23,8 @@ class SolarmanPVClient(Client):
 
         self.username = self.config.get('client.solarmanpv', 'username')
         self.password = self.config.get('client.solarmanpv', 'password')
+        # Get plant_id_list
+        self.plant_id_list = self.config.getlist('client.solarmanpv', 'plant_id_list', fallback=[])
 
     def initialize(self):
         pwhash = hashlib.md5(self.password.encode('utf-8')).hexdigest()
@@ -64,7 +66,7 @@ class SolarmanPVClient(Client):
     def getPlants(self):
 
         data = []
-        for plant in self.config.getlist('client.solarmanpv', 'plant_id_list'):
+        for plant in self.plant_id_list:
             data.append({'plant_id': plant})
 
         hybridlogger.ha_log(self.logger, self.hass_api, "DEBUG", f"plant list from config {data}")

--- a/apps/omnikdatalogger/omnik/plugin_client/tcpclient.py
+++ b/apps/omnikdatalogger/omnik/plugin_client/tcpclient.py
@@ -88,7 +88,7 @@ class TCPclient(Client):
                 hybridlogger.ha_log(self.logger, self.hass_api, "DEBUG", f"data size: {len(rawmsg)}.\n"
                                     f"Datadump: {str(binascii.b2a_base64(rawmsg))}")
         except Exception as e:
-            hybridlogger.ha_log(self.logger, self.hass_api, "WARNING", f"Error getting data from inverter. {e}")
+            hybridlogger.ha_log(self.logger, self.hass_api, "INFO", f"Inverter is not reachable, this is normal when it is dark. {e}")
             return None
 
         if valid:

--- a/apps/omnikdatalogger/omnik/plugin_localproxy/__init__.py
+++ b/apps/omnikdatalogger/omnik/plugin_localproxy/__init__.py
@@ -8,8 +8,9 @@ class LocalProxyBasePlugin(type):
         else:
             cls.register(cls)  # Called when a plugin class is imported
 
-    def register(cls, plugin):
-        cls.localproxy_plugins.append(plugin())
+    def register(cls, plugin=None):
+        if plugin:
+            cls.localproxy_plugins.append(plugin())
 
 
 class LocalProxyPlugin(object, metaclass=LocalProxyBasePlugin):

--- a/apps/omnikdatalogger/omnik/plugin_localproxy/hassapi.py
+++ b/apps/omnikdatalogger/omnik/plugin_localproxy/hassapi.py
@@ -9,7 +9,7 @@ class HASSAPI(LocalProxyPlugin):
     This plugin enables you to subscribe to the logger requests using the AppDaemon HASSAPI integration
     Use scripts/proxy/omnikloggerproxy.py to capture the inverter events and publish the data to MQTT (Home Assistant)
 
-    This class makes use the following localproxy client objects
+    This class makes use of the following localproxy client attributes
     self.client.msg
     self.client.msgevent
     self.client.semaphore
@@ -28,7 +28,7 @@ class HASSAPI(LocalProxyPlugin):
         # Deprecated property (use only if no plant specific configuration is available)
         self.legacy_logger_entity = self.config.get('client.localproxy.hassapi', 'logger_entity', 'binary_sensor.datalogger')
         self.logger_entity = []
-        for plant in self.config.getlist('client.localproxy', 'plant_id_list', []):
+        for plant in self.client.plant_id_list:
             entity = self.config.get(f'plant.{plant}', 'logger_entity', None)
             if entity:
                 self.logger_entity.append(entity)

--- a/apps/omnikdatalogger/omnik/plugin_localproxy/hassapi.py
+++ b/apps/omnikdatalogger/omnik/plugin_localproxy/hassapi.py
@@ -20,29 +20,39 @@ class HASSAPI(LocalProxyPlugin):
     def __init__(self):
         super().__init__()
         hybridlogger.ha_log(self.logger, self.hass_api, "INFO", "localproxy client plugin: HASSAPI")
-        self.hass_handle = None
+        self.hass_handle = {}
         if not self.hass_api:
             hybridlogger.ha_log(self.logger, self.hass_api,
                                 "ERROR", "No HassAPI detected. Use AppDaemon with Home Assistent for this plugin")
             return
-        self.logger_entity = self.config.get('client.localproxy.hassapi', 'logger_entity', 'binary_sensor.datalogger')
+        # Deprecated property (use only if no plant specific configuration is available)
+        self.legacy_logger_entity = self.config.get('client.localproxy.hassapi', 'logger_entity', 'binary_sensor.datalogger')
+        self.logger_entity = []
+        for plant in self.config.getlist('client.localproxy', 'plant_id_list', []):
+            entity = self.config.get(f'plant.{plant}', 'logger_entity', None)
+            if entity:
+                self.logger_entity.append(entity)
+        if self.legacy_logger_entity not in self.logger_entity:
+            self.logger_entity.append(self.legacy_logger_entity)
 
     def terminate(self):
         if self.hass_handle:
-            self.hass_api.cancel_listen_state(self.hass_handle)
+            for handle in self.hass_handle:
+                self.hass_api.cancel_listen_state(self.hass_handle[handle])
 
     def listen(self):
         if self.hass_api:
-            self.hass_handle = self.hass_api.listen_state(self._run, self.logger_entity, attribute='data')
-            hybridlogger.ha_log(self.logger, self.hass_api,
-                                "INFO", f"HASSapi listening to. '{self.logger_entity}', attribute: 'data'")
+            for logger_entity in self.logger_entity:
+                self.hass_handle[logger_entity] = self.hass_api.listen_state(self._run, logger_entity, attribute='data')
+                hybridlogger.ha_log(self.logger, self.hass_api,
+                                    "INFO", f"HASSapi listening to. '{logger_entity}', attribute: 'data'")
 
     def _run(self, entity, attribute, old, new, kwargs):
         # HASSAPI callback handler
         hybridlogger.ha_log(self.logger, self.hass_api,
                             "INFO",
-                            f"HASSapi state change for {self.hass_api.get_state(self.logger_entity, 'inverter', 'n/a')} "
-                            f"at {self.hass_api.get_state(self.logger_entity, 'last_update', 'n/a')}")
+                            f"HASSapi state change for {self.hass_api.get_state(entity, 'inverter', 'n/a')} "
+                            f"at {self.hass_api.get_state(entity, 'last_update', 'n/a')}")
         # Try to parse payload as json
         try:
             data = binascii.a2b_base64(new)

--- a/apps/omnikdatalogger/omnik/plugin_output/__init__.py
+++ b/apps/omnikdatalogger/omnik/plugin_output/__init__.py
@@ -14,7 +14,7 @@ class BasePlugin(type):
         else:
             cls.register(cls)  # Called when a plugin class is imported
 
-    def register(cls, plugin):
+    def register(cls, plugin=None):
         cls.plugins.append(plugin())
 
 

--- a/apps/omnikdatalogger/omnik/plugin_output/influxdb.py
+++ b/apps/omnikdatalogger/omnik/plugin_output/influxdb.py
@@ -25,6 +25,8 @@ class influxdb(Plugin):
         elif self.config.has_option('output.influxdb', 'username') and self.config.has_option('output.influxdb', 'password'):
             self.auth = requests.auth.HTTPBasicAuth(self.config.get('output.influxdb', 'username'),
                                                     self.config.get('output.influxdb', 'password'))
+        else:
+            self.auth = None
         self.timestamp_field = {}
         for field in self.config.data_field_config:
             if not self.config.data_field_config[field]['dev_cla'] == 'timestamp':
@@ -93,7 +95,7 @@ class influxdb(Plugin):
             self.access.acquire()
             msg = args['msg']
             hybridlogger.ha_log(self.logger, self.hass_api, "DEBUG",
-                                f"Loggin data to InfluxDB: {msg}")
+                                f"Logging data to InfluxDB: {msg}")
             values = msg.copy()
             # self._get_temperature(values)
 
@@ -121,6 +123,5 @@ class influxdb(Plugin):
         except Exception as e:
             hybridlogger.ha_log(self.logger, self.hass_api, "ERROR",
                                 f"Got unknown submitting to influxdb: {e.args} (ignoring: if this happens a lot ... fix it)")
-            raise e
         finally:
             self.access.release()

--- a/apps/omnikdatalogger/omnik/plugin_output/mqtt.py
+++ b/apps/omnikdatalogger/omnik/plugin_output/mqtt.py
@@ -101,12 +101,12 @@ class mqtt(Plugin):
         # Init from using mqtt field config (loaded from json)
         # self.config.data_field_config
         # field: name, dev_cla, ic, unit, filter
-
+        topic_suffix = f"_{msg['plant_id']}" if not msg['plant_id'] == '0' else ""
         topics = {}
         for asset_class in asset_classes:
             topics[asset_class] = {}
             topics[asset_class]['main'] = \
-                f"{self.discovery_prefix}/sensor/{self.config.attributes['devicename'][asset_class]}_{msg['plant_id']}"
+                f"{self.discovery_prefix}/sensor/{self.config.attributes['devicename'][asset_class]}{topic_suffix}"
             topics[asset_class]['state'] = f"{topics[asset_class]['main']}/state"
             topics[asset_class]['attr'] = f"{topics[asset_class]['main']}/attr"
             topics[asset_class]['config'] = {}

--- a/apps/omnikdatalogger/omnik/plugin_output/pvoutput.py
+++ b/apps/omnikdatalogger/omnik/plugin_output/pvoutput.py
@@ -47,8 +47,8 @@ class pvoutput(Plugin):
 
         if 'sys_id' not in msg:
             hybridlogger.ha_log(self.logger, self.hass_api, "ERROR",
-                                f'[{__name__}] No sys_id found in dataset, set sys_id under '
-                                'your plant settings or global under the output.pvoutput section')
+                                f'[{__name__}] No sys_id found in dataset, set sys_id  '
+                                'in the output.pvoutput section')
             return False
         return True
 


### PR DESCRIPTION
This PR will allow multiple inverters to be processed together.
With DSMR you now do not have to specify a plant_id any more, this will allow calculation of energy consumption over multiple inverters and even over more than one smart meter.

A limitation still is that only one client can be used, so you have to chose between solarmanpv, tcpclient or localproxy.

