### PR TITLE
Update deprecation icons (MQTT)

### DIFF
--- a/apps/omnikdatalogger/data_fields.json
+++ b/apps/omnikdatalogger/data_fields.json
@@ -205,7 +205,7 @@
     "power_ac1": {
         "name": "AC Power L1",
         "dev_cla": "power",
-        "ic": "flash-circle",
+        "ic": "lightning-bolt-circle",
         "unit": "W",
         "measurement": "power",
         "tags": {
@@ -218,7 +218,7 @@
     "power_ac2": {
         "name": "AC Power L2",
         "dev_cla": "power",
-        "ic": "flash-circle",
+        "ic": "lightning-bolt-circle",
         "unit": "W",
         "measurement": "power",
         "tags": {
@@ -231,7 +231,7 @@
     "power_ac3": {
         "name": "AC Power L3",
         "dev_cla": "power",
-        "ic": "flash-circle",
+        "ic": "lightning-bolt-circle",
         "unit": "W",
         "measurement": "power",
         "tags": {
@@ -611,7 +611,7 @@
     "INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE": {
         "name": "Net power usage L1",
         "dev_cla": "power",
-        "ic": "flash-circle",
+        "ic": "lightning-bolt-circle",
         "unit": "kW",
         "measurement": "power",
         "tags": {
@@ -624,7 +624,7 @@
     "INSTANTANEOUS_ACTIVE_POWER_L2_POSITIVE": {
         "name": "Net power usage L2",
         "dev_cla": "power",
-        "ic": "flash-circle",
+        "ic": "lightning-bolt-circle",
         "unit": "kW",
         "measurement": "power",
         "tags": {
@@ -637,7 +637,7 @@
     "INSTANTANEOUS_ACTIVE_POWER_L3_POSITIVE": {
         "name": "Net power usage L3",
         "dev_cla": "power",
-        "ic": "flash-circle",
+        "ic": "lightning-bolt-circle",
         "unit": "kW",
         "measurement": "power",
         "tags": {
@@ -650,7 +650,7 @@
     "INSTANTANEOUS_ACTIVE_POWER_L1_NEGATIVE": {
         "name": "Net power delivery L1",
         "dev_cla": "power",
-        "ic": "flash-circle",
+        "ic": "lightning-bolt-circle",
         "unit": "kW",
         "measurement": "power",
         "tags": {
@@ -663,7 +663,7 @@
     "INSTANTANEOUS_ACTIVE_POWER_L2_NEGATIVE": {
         "name": "Net power delivery L2",
         "dev_cla": "power",
-        "ic": "flash-circle",
+        "ic": "lightning-bolt-circle",
         "unit": "kW",
         "measurement": "power",
         "tags": {
@@ -676,7 +676,7 @@
     "INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE": {
         "name": "Net Power delivery L3",
         "dev_cla": "power",
-        "ic": "flash-circle",
+        "ic": "lightning-bolt-circle",
         "unit": "kW",
         "measurement": "power",
         "tags": {
@@ -689,7 +689,7 @@
     "current_net_power": {
         "name": "Current net power",
         "dev_cla": "power",
-        "ic": "flash-circle",
+        "ic": "lightning-bolt-circle",
         "unit": "W",
         "measurement": "power",
         "tags": {
@@ -701,7 +701,7 @@
     "current_net_power_l1": {
         "name": "Current net power L1",
         "dev_cla": "power",
-        "ic": "flash-circle",
+        "ic": "lightning-bolt-circle",
         "unit": "W",
         "measurement": "power",
         "tags": {
@@ -714,7 +714,7 @@
     "current_net_power_l2": {
         "name": "Current net power L2",
         "dev_cla": "power",
-        "ic": "flash-circle",
+        "ic": "lightning-bolt-circle",
         "unit": "W",
         "measurement": "power",
         "tags": {
@@ -727,7 +727,7 @@
     "current_net_power_l3": {
         "name": "Current net power L3",
         "dev_cla": "power",
-        "ic": "flash-circle",
+        "ic": "lightning-bolt-circle",
         "unit": "W",
         "measurement": "power",
         "tags": {

--- a/apps/omnikdatalogger/omnik/__init__.py
+++ b/apps/omnikdatalogger/omnik/__init__.py
@@ -8,7 +8,7 @@ import threading
 
 logging.basicConfig(stream=sys.stdout, level=os.environ.get("LOGLEVEL", logging.INFO))
 
-__version__ = "1.7.2"
+__version__ = "1.7.3"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
- Icon `mdi:flash-circle` was renamed to `mdi:lightning-bolt-circle` in `data_fields.json` due to deprecation.