### PR TITLE
Further logging improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ optional arguments:
   --data_config FILE  Path to data_fields.json configuration file
   --persistant_cache_file FILE  Path to writable cache json file to store last power en total energy
   --interval n  execute every n seconds
-  -d, --debug    debug mode
+  -l {DEBUG,INFO,WARNING,ERROR}, --loglevel {DEBUG,INFO,WARNING,ERROR} Loglevel
 ```
 
 > De default location for config using the commandline is `~/.omnik/config.yaml`.

--- a/apps/omnikdatalogger/omnik/plugin_localproxy/hassapi.py
+++ b/apps/omnikdatalogger/omnik/plugin_localproxy/hassapi.py
@@ -72,7 +72,7 @@ class HASSAPI(LocalProxyPlugin):
         hybridlogger.ha_log(
             self.logger,
             self.hass_api,
-            "INFO",
+            "DEBUG",
             f"HASSapi state change for {self.hass_api.get_state(entity, 'inverter', 'n/a')} "
             f"at {self.hass_api.get_state(entity, 'last_update', 'n/a')}",
         )

--- a/apps/omnikdatalogger/omniklogger.py
+++ b/apps/omnikdatalogger/omniklogger.py
@@ -23,6 +23,13 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+LOGLEVEL = {
+    "DEBUG": logger.setLevel(logging.DEBUG),
+    "INFO": logger.setLevel(logging.INFO),
+    "WARNING": logger.setLevel(logging.WARNING),
+    "ERROR": logger.setLevel(logging.ERROR),
+}
+
 # customize config parser with dict based lookup for AppDaemon and command line options
 # has_option and get function have been adapted
 ha_args = {}
@@ -172,6 +179,8 @@ def main(c: ha_ConfigParser, hass_api=None):
     # Enabled debugging if the flag is set
     if c.get("default", "debug", False):
         logger.setLevel(logging.DEBUG)
+    if c.get("default", "loglevel"):
+        logger.setLevel(LOGLEVEL.get(c.get("default", "loglevel")))
 
     set_data_config_path(c)
     datalogger = DataLogger(c, hass_api=hass_api)
@@ -346,8 +355,14 @@ if __name__ == "__main__":
         metavar="FILE",
     )
     parser.add_argument("--interval", type=int, help="Execute every n seconds")
-
     parser.add_argument("-d", "--debug", action="store_true", help="Debug mode")
+    parser.add_argument(
+        "-l",
+        "--loglevel",
+        help="Loglevel",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION
New command line option to set log level (replaces the -d debug option which is deprecated now).
Hassapi logging -> DEBUG log.