### PR TITLE
store tcpclient mode per plant

### DIFF
--- a/apps/omnikdatalogger/omnik/__init__.py
+++ b/apps/omnikdatalogger/omnik/__init__.py
@@ -8,7 +8,7 @@ import threading
 
 logging.basicConfig(stream=sys.stdout, level=os.environ.get("LOGLEVEL", logging.INFO))
 
-__version__ = "1.9.0-beta-5"
+__version__ = "1.9.0-beta-6"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
When multiple inverters are configured that support a different access mode the cached mode should be stored per plant.