### PR TITLE
Add new CSV logger plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Details for the plant are set in section `plant.{plant id}]`. Replace _plant_id_
 | `separator`        | True     | string | _;_                                    | Used by the client `csvoutput`. The separator/delimiter to use between headers and fields. Use '\t' to use a tab as separator.                                                                             |
 | `no_headers`       | True     | bool   | _False_                                | Used by the client `csvoutput`. If `csvoutput` will not write headers to the `csvfile`.                                                                                                                    |
 | `fields`           | True     | list   | _[*]_                                  | Used by the client `csvoutput`. A list of fields to log. The fields `date` and `time` are specials fields to log the local date and time.                                                                  |
+| `use_temperature`  | True     | bool   | _False_                                | When set to true the `temperature` field is set in the data set which can be logged to CSV. The value is obtained from OpenWeatherMap.                                                                     |
 
 [*] == [
 "date",

--- a/README.md
+++ b/README.md
@@ -122,69 +122,81 @@ This configuration is placed in the file: `/config/appdaemon/apps/apps.yaml`.
 ```yaml
 # The instance name is omnik_datalogger, this can be changed. Multiple instances are supported.
 omnik_datalogger:
-# General options
+  # General options
   module: omniklogger
   class: HA_OmnikDataLogger
   city: Amsterdam
   interval: 360
 
-# plugin section
+  # plugin section
   plugins:
-# plugins for data logging (output)
+    # plugins for data logging (output)
     output:
       - pvoutput
       - mqtt
       - influxdb
-# plugins for local proxy client (list)
+      - csvoutput
+    # plugins for local proxy client (list)
     localproxy:
       - hassapi
-#     - mqtt_proxy
-#     - tcp_proxy
-# the client that is beging used (choose one)
-# valid clients are localproxy, solarmanpv and tcpclient
+    #     - mqtt_proxy
+    #     - tcp_proxy
+    # the client that is beging used (choose one)
+    # valid clients are localproxy, solarmanpv and tcpclient
     client: localproxy
 
-# attributes override
+  # attributes override
   attributes:
     devicename.omnik: Omvormer
-#   model.omnik: Omnik data logger
+  #   model.omnik: Omnik data logger
 
-#DSMR support
+  #DSMR support
   dsmr:
     terminals:
       - term1
     tarif:
-      - '0001'
-      - '0002'
+      - "0001"
+      - "0002"
     tarif.0001: laag
     tarif.0002: normaal
 
   dsmr.term1:
-# use mode tcp or device
+    # use mode tcp or device
     mode: tcp
     host: 172.17.0.1
     port: 3333
     device: /dev/ttyUSB0
-    dsmr_version: '5'
+    dsmr_version: "5"
     total_energy_offset: 15338.0
     gas_meter: true
 
-# Section for your inverters specific settings
+  # Section for your inverters specific settings
   plant.123:
     inverter_address: 192.168.1.1
     logger_sn: 123456789
     inverter_port: 8899
     inverter_sn: NLxxxxxxxxxxxxxx
     sys_id: <YOUR SYSTEM ID>
+    # CSV output for specific plant
+    csvfile: "/some_path/output.178735.csv"
+    separator: ";"
+    no_headers: false
+    fields:
+      - date
+      - time
+      - current_power
+      - today_energy
+      - total_energy
+      - inverter
 
-# Section for the localproxy client
+  # Section for the localproxy client
   client.localproxy:
     plant_id_list:
-      - '123'
-# Section for the localproxy plugin hassapi
+      - "123"
+  # Section for the localproxy plugin hassapi
   client.localproxy.hassapi:
     logger_entity: binary_sensor.datalogger
-# Section for the localproxy plugin mqtt_proxy
+  # Section for the localproxy plugin mqtt_proxy
   client.localproxy.mqtt_proxy:
     logger_sensor_name: Datalogger
     discovery_prefix: homeassistant
@@ -193,17 +205,17 @@ omnik_datalogger:
     client_name_prefix: ha-mqtt-omniklogger
     username: mqttuername
     password: mqttpasswordabcdefgh
-# Section for the localproxy plugin tcp_proxy
+  # Section for the localproxy plugin tcp_proxy
   client.localproxy.tcp_proxy:
-    listen_address: '0.0.0.0'
-    listen_port: '10004'
+    listen_address: "0.0.0.0"
+    listen_port: "10004"
 
-# Solarmanpv API options
+  # Solarmanpv API options
   client.solarmanpv:
     username: john.doe@example.com
     password: some_password
 
-# Influxdb output plugin configuration options
+  # Influxdb output plugin configuration options
   output.influxdb:
     host: localhost
     port: 8086
@@ -211,9 +223,23 @@ omnik_datalogger:
     username: omnikdatalogger
     password: mysecretpassword
     #jwt_token=
-    use_temperature=true
+    use_temperature: true
 
-# PVoutput output plugin configuration options
+  # csvoutput output plugin configuration options
+  output.csvoutput:
+    # CSV output for aggregated data
+    csvfile: "/some_path/output.csv"
+    separator: ";"
+    no_headers: false
+    fields:
+      - date
+      - time
+      - current_power
+      - today_energy
+      - total_energy
+      - inverter
+
+  # PVoutput output plugin configuration options
   output.pvoutput:
     sys_id: 12345
     api_key: jadfjlasexample0api0keykfjasldfkajdflasd
@@ -221,7 +247,7 @@ omnik_datalogger:
     use_inverter_temperature: true
     publish_voltage: voltage_ac_max
 
-# Open Weather map options
+  # Open Weather map options
   openweathermap:
     api_key: someexampleapikeygenerateone4you
     endpoint: api.openweathermap.org
@@ -229,7 +255,7 @@ omnik_datalogger:
     lat: 50.1234567
     units: metric
 
-# MQTT output plugin configuration options
+  # MQTT output plugin configuration options
   output.mqtt:
     username: mqttuername
     password: mqttpasswordabcdefgh
@@ -314,7 +340,6 @@ omnik_datalogger:
     energy_direct_use_name: Direct verbruikt
     power_consumption_name: Verbruik
     power_direct_use_name: Direct verbruik
-
 ```
 
 ## Configuration keys (required, optional and defaults)
@@ -343,11 +368,11 @@ The first section in `config.yaml` will be used (see event log).
 
 #### Plugin settings in the section `plugins` of `apps.yaml` or `config.yaml`
 
-| key          | optional | type   | default        | description                                                                                                                                                                                     |
-| ------------ | -------- | ------ | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `client`     | False    | string | _(none)_       | Name of the client that will be used to fetch the data. Valid choices are `localproxy`, `tcp_client`, or `solarmanpv`.                                                                          |
-| `localproxy` | True     | list   | _(none)_       | The client plugings for the `localproxy` client that will be used to fetch the data. Valid choices are `tcp_proxy`, `mqtt_proxy` or `hassapi`.                                                  |
-| `output`     | True     | list   | _(empty list)_ | A (yaml) list of string specifying the name(s) of the output plugins to be used. Available plugins are _pvoutput_, _influxdb_ and _mqtt_. If no plugins are configured, nothing will be logged. |
+| key          | optional | type   | default        | description                                                                                                                                                                                                  |
+| ------------ | -------- | ------ | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `client`     | False    | string | _(none)_       | Name of the client that will be used to fetch the data. Valid choices are `localproxy`, `tcp_client`, or `solarmanpv`.                                                                                       |
+| `localproxy` | True     | list   | _(none)_       | The client plugings for the `localproxy` client that will be used to fetch the data. Valid choices are `tcp_proxy`, `mqtt_proxy` or `hassapi`.                                                               |
+| `output`     | True     | list   | _(empty list)_ | A (yaml) list of string specifying the name(s) of the output plugins to be used. Available plugins are `pvoutput`, `influxdb`, `csvoutput` and `mqtt`. If no plugins are configured, nothing will be logged. |
 
 #### DSMR settings in the section `dsmr` of `apps.yaml` or `config.yaml`
 
@@ -387,6 +412,18 @@ Details for the plant are set in section `plant.{plant id}]`. Replace _plant_id_
 | `http_only`        | True     | bool   | _False_                                | Used by the client `tcpclient`. The client will not try to connect the inverter over port `8899` but will use the fallback method to fetch a status update using http://{inverter_address}:80/js/status.js |
 | `sys_id`           | True     | int    | _`sys_id` at the `[pvoutput]` section_ | Your unique system id, generated when creating an account at pvoutput.org. This setting allows the specific inveterdata to be published at pvoutput.org. See `pvoutput` settings for more information.     |
 | `logger_entity`    | True     | string | _(none)_                               | When using the `localproxy` client with `hassapi`, this specifies the inverter entity created through `omnikdataloggerproxy` that receives new updates for the inverter.                                   |
+| `csvfile`          | True     | string | _(none)_                               | Used by the client `csvoutput`. The file and path to append or create for csv logging.                                                                                                                     |
+| `separator`        | True     | string | _;_                                    | Used by the client `csvoutput`. The separator/delimiter to use between headers and fields. Use '\t' to use a tab as separator.                                                                             |
+| `no_headers`       | True     | bool   | _False_                                | Used by the client `csvoutput`. If `csvoutput` will not write headers to the `csvfile`.                                                                                                                    |
+| `fields`           | True     | list   | _[*]_                                  | Used by the client `csvoutput`. A list of fields to log. The fields `date` and `time` are specials fields to log the local date and time.                                                                  |
+
+[*] == [
+"date",
+"time",
+"current_power",
+"today_energy",
+"total_energy",
+]
 
 ### TCPclient client settings in the section `client.tcpclient` of `apps.yaml` or `config.yaml`
 
@@ -583,6 +620,24 @@ Register a free acount and API key at https://pvoutput.org/register.jsp
 | `use_inverter_temperature` | True     | bool   | `false`  | When set to true and `use_temperature` is set, the inverter temperature is submitted to pvoutput.org when logging the data. Only the clients `tcpclient` and `localproxy` are supported.                                                                                                                                                                                                                                                                                                                                                                                         |
 | `publish_voltage`          | True     | string | _(none)_ | The _fieldname_ key of the voltage property to use for pvoutput 'addstatus' publishing. When set to `'voltage_ac_max'`, the maximal inverter AC voltage over all fases is submitted to pvoutput.org when logging the data. Only the clients `tcpclient` and `localproxy` are supported. Supported values are `voltage_ac1`, `voltage_ac2`, `voltage_ac3` or `voltage_ac_max` or one ofe the DSMR voltage fields (INSTANTANEOUS_VOLTAGE_L1 / \_L2, \_L3 or net_voltage_max) if DSMR is available. The field `net_voltage_max` holds the highest voltage over all available fases. |
 | `net_voltage_fallback `    | True     | string | _(none)_ | The _fieldname_ key of the voltage property to use for pvoutput 'addstatus' publishing in case no solar data is available during sun down. When set to `'net_voltage_max'`, the maximal net voltage over all fases is submitted as alternative to pvoutput.org. This key only makes sens when using the DSMR integration.                                                                                                                                                                                                                                                        |
+
+### CSVoutput plugin settings in the section `output.csvoutput` in of `apps.yaml` or `config.yaml`
+
+| key               | optional | type   | default  | description                                                                                                                               |
+| ----------------- | -------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `csvfile`         | True     | string | _(none)_ | Used by the client `csvoutput`. The file and path to append or create for csv logging.                                                    |
+| `separator`       | True     | string | _;_      | Used by the client `csvoutput`. The separator/delimiter to use between headers and fields. Use '\t' to use a tab as separator.            |
+| `no_headers`      | True     | bool   | _False_  | Used by the client `csvoutput`. If `csvoutput` will not write headers to the `csvfile`.                                                   |
+| `fields`          | True     | list   | _[*]_    | Used by the client `csvoutput`. A list of fields to log. The fields `date` and `time` are specials fields to log the local date and time. |
+| `use_temperature` | True     | bool   | _False_  | When set to true the `temperature` field is set in the data set which can be logged. The value is obtained from OpenWeatherMap.           |
+
+[*] == [
+"date",
+"time",
+"current_power",
+"today_energy",
+"total_energy",
+]
 
 ### InfluxDB plugin settings in the section `output.influxdb` in of `apps.yaml` or `config.yaml`
 

--- a/apps/omnikdatalogger/omnik/datalogger.py
+++ b/apps/omnikdatalogger/omnik/datalogger.py
@@ -715,6 +715,8 @@ class DataLogger(object):
                 "inverter_temperature",
             ]:
                 self._init_aggregated_data_field(aggregated_data, data, field)
+            if data.get("cached"):
+                aggregated_data["cached"] = True
             if self.dsmr:
                 for field in [
                     # Attributes Electricity for pvoutput
@@ -803,29 +805,28 @@ class DataLogger(object):
         else:
             # Get sys_id from pvoutput section, cannot aggregate without sys_id
             sys_id = global_sys_id
-            if sys_id:
-                # Aggerate data (initialize dict and set sys_id)
-                self._init_aggregated_data(aggregated_data, data, sys_id)
-                # Timestamp
-                self._adapt_max_value(aggregated_data, data, "last_update")
-                # Add energy
-                self._adapt_add_value(aggregated_data, data, "today_energy")
-                self._adapt_add_value(aggregated_data, data, "total_energy")
-                # Add power
-                self._adapt_add_value(aggregated_data, data, "current_power")
-                # Max voltage
-                self._adapt_max_value(aggregated_data, data, "voltage_ac_max")
-                self._adapt_max_value(aggregated_data, data, "voltage_ac1")
-                self._adapt_max_value(aggregated_data, data, "voltage_ac2")
-                self._adapt_max_value(aggregated_data, data, "voltage_ac3")
-                self._adapt_max_value(aggregated_data, data, "net_voltage_max")
-                # Max current
-                self._adapt_max_value(aggregated_data, data, "current_ac1")
-                self._adapt_max_value(aggregated_data, data, "current_ac2")
-                self._adapt_max_value(aggregated_data, data, "current_ac3")
-                # Max inverter temperature
-                self._adapt_max_value(aggregated_data, data, "inverter_temperature")
-            if sys_id and self.dsmr:
+            # Aggerate data (initialize dict and set sys_id)
+            self._init_aggregated_data(aggregated_data, data, sys_id)
+            # Timestamp
+            self._adapt_max_value(aggregated_data, data, "last_update")
+            # Add energy
+            self._adapt_add_value(aggregated_data, data, "today_energy")
+            self._adapt_add_value(aggregated_data, data, "total_energy")
+            # Add power
+            self._adapt_add_value(aggregated_data, data, "current_power")
+            # Max voltage
+            self._adapt_max_value(aggregated_data, data, "voltage_ac_max")
+            self._adapt_max_value(aggregated_data, data, "voltage_ac1")
+            self._adapt_max_value(aggregated_data, data, "voltage_ac2")
+            self._adapt_max_value(aggregated_data, data, "voltage_ac3")
+            self._adapt_max_value(aggregated_data, data, "net_voltage_max")
+            # Max current
+            self._adapt_max_value(aggregated_data, data, "current_ac1")
+            self._adapt_max_value(aggregated_data, data, "current_ac2")
+            self._adapt_max_value(aggregated_data, data, "current_ac3")
+            # Max inverter temperature
+            self._adapt_max_value(aggregated_data, data, "inverter_temperature")
+            if self.dsmr:
                 self._adapt_add_value(aggregated_data, data, "power_consumption")
                 self._adapt_add_value(aggregated_data, data, "energy_used_net")
                 self._adapt_add_value(aggregated_data, data, "energy_used")
@@ -1228,6 +1229,7 @@ class DataLogger(object):
                     # Use cached data for aggregation with DSMR
                     data = {}
                     try:
+                        data["cached"] = True
                         data["plant_id"] = plant
                         data["last_update"] = self.get_last_update(plant)
                         data["total_energy"] = self.total_energy(plant)

--- a/apps/omnikdatalogger/omnik/plant.py
+++ b/apps/omnikdatalogger/omnik/plant.py
@@ -1,12 +1,13 @@
-from datetime import datetime, timezone, time
+from datetime import datetime, timezone
+from time import time
 from decimal import Decimal
 
 
 class Plant:
-    def __init__(self, plant_id=None, last_update_time=None, *args, **kwargs):
+    def __init__(self, plant_id=None, last_update_time=time(), *args, **kwargs):
         self._plant_id = plant_id
-        self._last_update_time = (
-            last_update_time if last_update_time else datetime.now(timezone.utc)
+        self._last_update_time = datetime.fromtimestamp(last_update_time).astimezone(
+            timezone.utc
         )
         self._updated = bool(last_update_time)
         self._data = None
@@ -30,7 +31,7 @@ class Plant:
                     f"{self._plant_id}.last_today_energy"
                 ]
                 self._data["current_power"] = Decimal("0.0")
-                self._data["last_update"] = time.time()
+                self._data["last_update"] = time()
             except:
                 return False
             return True

--- a/apps/omnikdatalogger/omnik/plugin_client/solarmanpv.py
+++ b/apps/omnikdatalogger/omnik/plugin_client/solarmanpv.py
@@ -145,13 +145,13 @@ class OmnikPortalClient(Client):
                     data.append(
                         {
                             "plant_id": f'{str(station.get("id"))},{str(device.get("deviceSn"))}',
-                            "last_update": device.get("collectionTime"),
                         }
                     )
 
         return data
 
     def getPlantData(self, plant_id):
+        """Get the data for a specific plant."""
 
         # we collect our data in `data` but we need a serial number to query the API, we extract this from plant_id
         data = {}

--- a/apps/omnikdatalogger/omnik/plugin_output/__init__.py
+++ b/apps/omnikdatalogger/omnik/plugin_output/__init__.py
@@ -24,6 +24,7 @@ class Plugin(object, metaclass=BasePlugin):
     logger = None
     hass_api = None
     process_aggregates = False
+    process_output = False
 
     cache = TTLCache(maxsize=1, ttl=300)
 

--- a/apps/omnikdatalogger/omnik/plugin_output/csvoutput.py
+++ b/apps/omnikdatalogger/omnik/plugin_output/csvoutput.py
@@ -90,6 +90,9 @@ class csvoutput(Plugin):
         no_headers = self.config.getboolean(
             config_section, "no_headers", fallback=False
         )
+        use_temperature = self.config.getboolean(
+            config_section, "use_temperature", fallback=False
+        )
         if fields and fields[0] and csvfile:
             hybridlogger.ha_log(
                 self.logger,
@@ -129,7 +132,8 @@ class csvoutput(Plugin):
             # Append the log
             with open(csvfile, "a") as file_object:
                 reporttime = localtime(msg["last_update"])
-                self._get_temperature(msg)
+                if use_temperature:
+                    msg.update({"temperature": self._get_temperature(msg)})
                 msg.update(
                     {
                         "date": strftime("%Y-%m-%d", reporttime),

--- a/apps/omnikdatalogger/omnik/plugin_output/mqtt.py
+++ b/apps/omnikdatalogger/omnik/plugin_output/mqtt.py
@@ -1,7 +1,6 @@
 import pytz
 import json
 import time
-import ssl
 
 from omnik.ha_logger import hybridlogger
 

--- a/info.md
+++ b/info.md
@@ -99,7 +99,7 @@ omnik_datalogger:
     sys_id: <YOUR SYSTEM ID>
     # CSV output for specific plant
     csvfile: "/some_path/output.178735.csv"
-    separator: ";"
+    separator: ;
     no_headers: false
     fields:
       - date
@@ -108,6 +108,10 @@ omnik_datalogger:
       - today_energy
       - total_energy
       - inverter
+      - plant_id
+      - inverter_temperature
+      - temperature
+    use_temperature: true
 
   # Section for the localproxy client
   client.localproxy:
@@ -324,6 +328,7 @@ Details for each plant are set in section `plant.{plant id}]`. Every plant has i
 | `separator`        | True     | string | _;_                                    | Used by the client `csvoutput`. The separator/delimiter to use between headers and fields. Use '\t' to use a tab as separator.                                                                             |
 | `no_headers`       | True     | bool   | _False_                                | Used by the client `csvoutput`. If `csvoutput` will not write headers to the `csvfile`.                                                                                                                    |
 | `fields`           | True     | list   | _[*]_                                  | Used by the client `csvoutput`. A list of fields to log. The fields `date` and `time` are specials fields to log the local date and time.                                                                  |
+| `use_temperature`  | True     | bool   | _False_                                | When set to true the `temperature` field is set in the data set which can be logged to CSV. The value is obtained from OpenWeatherMap.                                                                     |
 
 [*] == [
 "date",

--- a/info.md
+++ b/info.md
@@ -41,70 +41,82 @@ See for more information and documentation about AppDaemon: https://appdaemon.re
 ```yaml
 # The instance name is omnik_datalogger, this can be changed. Multiple instances are supported.
 omnik_datalogger:
-# General options
+  # General options
   module: omniklogger
   class: HA_OmnikDataLogger
   city: Amsterdam
   interval: 360
 
-# plugin section
+  # plugin section
   plugins:
-# plugins for data logging (output)
+    # plugins for data logging (output)
     output:
       - pvoutput
       - mqtt
       - influxdb
-# plugins for local proxy client (list)
+      - csvoutput
+    # plugins for local proxy client (list)
     localproxy:
       - hassapi
-#     - mqtt_proxy
-#     - tcp_proxy
-# the client that is beging used (choose one)
-# valid clients are localproxy, solarmanpv and tcpclient
+    #     - mqtt_proxy
+    #     - tcp_proxy
+    # the client that is beging used (choose one)
+    # valid clients are localproxy, solarmanpv and tcpclient
     client: localproxy
 
-# attributes override
+  # attributes override
   attributes:
     devicename.omnik: Omvormer
-#   model.omnik: Omnik data logger
+  #   model.omnik: Omnik data logger
 
-#DSMR support
+  #DSMR support
   dsmr:
     terminals:
       - term1
     tarif:
-      - '0001'
-      - '0002'
+      - "0001"
+      - "0002"
     tarif.0001: laag
     tarif.0002: normaal
 
   dsmr.term1:
-# use mode tcp or device
+    # use mode tcp or device
     mode: tcp
     host: 172.17.0.1
     port: 3333
     device: /dev/ttyUSB0
-    dsmr_version: '5'
+    dsmr_version: "5"
     # plant_id: '123' # not needed in most cases
     total_energy_offset: 15338.0
     gas_meter: true
 
-# Section for your inverters specific settings
+  # Section for your inverters specific settings
   plant.123:
     inverter_address: 192.168.1.1
     logger_sn: 123456789
     inverter_port: 8899
     inverter_sn: NLxxxxxxxxxxxxxx
     sys_id: <YOUR SYSTEM ID>
+    # CSV output for specific plant
+    csvfile: "/some_path/output.178735.csv"
+    separator: ";"
+    no_headers: false
+    fields:
+      - date
+      - time
+      - current_power
+      - today_energy
+      - total_energy
+      - inverter
 
-# Section for the localproxy client
+  # Section for the localproxy client
   client.localproxy:
     plant_id_list:
-      - '123'
-# Section for the localproxy plugin hassapi
+      - "123"
+  # Section for the localproxy plugin hassapi
   client.localproxy.hassapi:
     logger_entity: binary_sensor.datalogger
-# Section for the localproxy plugin mqtt_proxy
+  # Section for the localproxy plugin mqtt_proxy
   client.localproxy.mqtt_proxy:
     logger_sensor_name: Datalogger
     discovery_prefix: homeassistant
@@ -113,17 +125,17 @@ omnik_datalogger:
     client_name_prefix: ha-mqtt-omniklogger
     username: mqttuername
     password: mqttpasswordabcdefgh
-# Section for the localproxy plugin tcp_proxy
+  # Section for the localproxy plugin tcp_proxy
   client.localproxy.tcp_proxy:
-    listen_address: '0.0.0.0'
-    listen_port: '10004'
+    listen_address: "0.0.0.0"
+    listen_port: "10004"
 
-# SolarmanPV portal options
+  # SolarmanPV portal options
   client.solarmanpv:
     username: john.doe@example.com
     password: some_password
 
-# Influxdb output plugin configuration options
+  # Influxdb output plugin configuration options
   output.influxdb:
     host: localhost
     port: 8086
@@ -131,9 +143,23 @@ omnik_datalogger:
     username: omnikdatalogger
     password: mysecretpassword
     #jwt_token=
-    use_temperature=true
+    use_temperature: true
 
-# PVoutput output plugin configuration options
+  # csvoutput output plugin configuration options
+  output.csvoutput:
+    # CSV output for aggregated data
+    csvfile: "/some_path/output.csv"
+    separator: ";"
+    no_headers: false
+    fields:
+      - date
+      - time
+      - current_power
+      - today_energy
+      - total_energy
+      - inverter
+
+  # PVoutput output plugin configuration options
   output.pvoutput:
     sys_id: 12345
     api_key: jadfjlasexample0api0keykfjasldfkajdflasd
@@ -141,7 +167,7 @@ omnik_datalogger:
     use_inverter_temperature: true
     publish_voltage: voltage_ac_max
 
-# Open Weather map options
+  # Open Weather map options
   openweathermap:
     api_key: someexampleapikeygenerateone4you
     endpoint: api.openweathermap.org
@@ -149,7 +175,7 @@ omnik_datalogger:
     lat: 50.1234567
     units: metric
 
-# MQTT output plugin configuration options
+  # MQTT output plugin configuration options
   output.mqtt:
     username: mqttuername
     password: mqttpasswordabcdefgh
@@ -250,11 +276,11 @@ omnik_datalogger:
 
 #### Enable plugins in the section `plugins`
 
-| key          | optional | type   | default        | description                                                                                                                                                                                                             |
-| ------------ | -------- | ------ | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `client`     | False    | string | _(none)_       | Name of the client that will be used to fetch the data. Valid choices are `localproxy`, `tcp_client` or `solarmanpv`.                                                                                                   |
-| `localproxy` | True     | list   | _(none)_       | The client plugings for the `localproxy` client that will be used to fetch the data. Valid choices are `tcp_proxy`, `mqtt_proxy` or `hassapi`.                                                                          |
-| `output`     | True     | list   | _(empty list)_ | A (comma separated) list or yaml list of string specifying the name(s) of the output plugins to be used. Available plugins are _pvoutput_, _influxdb_ and _mqtt_. If no plugins are configured, nothing will be logged. |
+| key          | optional | type   | default        | description                                                                                                                                                                                                                          |
+| ------------ | -------- | ------ | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `client`     | False    | string | _(none)_       | Name of the client that will be used to fetch the data. Valid choices are `localproxy`, `tcp_client` or `solarmanpv`.                                                                                                                |
+| `localproxy` | True     | list   | _(none)_       | The client plugings for the `localproxy` client that will be used to fetch the data. Valid choices are `tcp_proxy`, `mqtt_proxy` or `hassapi`.                                                                                       |
+| `output`     | True     | list   | _(empty list)_ | A (comma separated) list or yaml list of string specifying the name(s) of the output plugins to be used. Available plugins are `pvoutput`, `influxdb`, `mqtt` and `csvoutput`. If no plugins are configured, nothing will be logged. |
 
 #### DSMR settings in the section `dsmr` of `apps.yaml`
 
@@ -294,6 +320,18 @@ Details for each plant are set in section `plant.{plant id}]`. Every plant has i
 | `http_only`        | True     | bool   | _False_                                | Used by the client `tcpclient`. The client will not try to connect the inverter over port `8899` but will use the fallback method to fetch a status update using http://{inverter_address}:80/js/status.js |
 | `sys_id`           | True     | int    | _`sys_id` at the `[pvoutput]` section_ | Your unique system id, generated when creating an account at pvoutput.org. This setting allows the specific inveterdata to be published at pvoutput.org. See `pvoutput` settings for more information.     |
 | `logger_entity`    | True     | string | _(none)_                               | When using the `localproxy` client with `hassapi`, this specifies the inverter entity created through `omnikdataloggerproxy` that receives new updates for the inverter.                                   |
+| `csvfile`          | True     | string | _(none)_                               | Used by the client `csvoutput`. The file and path to append or create for csv logging.                                                                                                                     |
+| `separator`        | True     | string | _;_                                    | Used by the client `csvoutput`. The separator/delimiter to use between headers and fields. Use '\t' to use a tab as separator.                                                                             |
+| `no_headers`       | True     | bool   | _False_                                | Used by the client `csvoutput`. If `csvoutput` will not write headers to the `csvfile`.                                                                                                                    |
+| `fields`           | True     | list   | _[*]_                                  | Used by the client `csvoutput`. A list of fields to log. The fields `date` and `time` are specials fields to log the local date and time.                                                                  |
+
+[*] == [
+"date",
+"time",
+"current_power",
+"today_energy",
+"total_energy",
+]
 
 #### LocalProxy client settings in the section `client.localproxy` of `apps.yaml`
 
@@ -484,6 +522,24 @@ Register a free acount and API key at https://pvoutput.org/register.jsp
 | `use__inverter_temperature` | True     | bool   | `false`  | When set to true and `use_temperature` is set, the inverter temperature is submitted to pvoutput.org when logging the data. Only the clients `tcpclient` and `localproxy` are supported.                                                                                                                                                                                                                                                                                                                                                                                         |
 | `publish_voltage`           | True     | string | _(none)_ | The _fieldname_ key of the voltage property to use for pvoutput 'addstatus' publishing. When set to `'voltage_ac_max'`, the maximal inverter AC voltage over all fases is submitted to pvoutput.org when logging the data. Only the clients `tcpclient` and `localproxy` are supported. Supported values are `voltage_ac1`, `voltage_ac2`, `voltage_ac3` or `voltage_ac_max` or one ofe the DSMR voltage fields (INSTANTANEOUS_VOLTAGE_L1 / \_L2, \_L3 or net_voltage_max) if DSMR is available. The field `net_voltage_max` holds the highest voltage over all available fases. |
 | `net_voltage_fallback `     | True     | string | _(none)_ | The _fieldname_ key of the voltage property to use for pvoutput 'addstatus' publishing in case no solar data is available during sun down. When set to `'net_voltage_max'`, the maximal net voltage over all fases is submitted as alternative to pvoutput.org. This key only makes sens when using the DSMR integration.                                                                                                                                                                                                                                                        |
+
+### CSVoutput plugin settings in the section `output.csvoutput` of `apps.yaml`
+
+| key               | optional | type   | default  | description                                                                                                                               |
+| ----------------- | -------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `csvfile`         | True     | string | _(none)_ | Used by the client `csvoutput`. The file and path to append or create for csv logging.                                                    |
+| `separator`       | True     | string | _;_      | Used by the client `csvoutput`. The separator/delimiter to use between headers and fields. Use '\t' to use a tab as separator.            |
+| `no_headers`      | True     | bool   | _False_  | Used by the client `csvoutput`. If `csvoutput` will not write headers to the `csvfile`.                                                   |
+| `fields`          | True     | list   | _[*]_    | Used by the client `csvoutput`. A list of fields to log. The fields `date` and `time` are specials fields to log the local date and time. |
+| `use_temperature` | True     | bool   | _False_  | When set to true the `temperature` field is set in the data set which can be logged. The value is obtained from OpenWeatherMap.           |
+
+[*] == [
+"date",
+"time",
+"current_power",
+"today_energy",
+"total_energy",
+]
 
 ### InfluxDB plugin settings in the section `output.influxdb` of `apps.yaml`
 


### PR DESCRIPTION
The PR adds a new output plugin `csvoutput` that enables logging to CSV file. A new section has been added `output.csvoutput` to configure aggegated logging of accumulated data of all configured inverters.
Logging of a specific inverter is possible as well. This is configured under the plant specific settings. You can log detail data of multiple inverters to the same file as long as the configured fields are the same.
Additional the temperature can be logged using the built-in openweathermap API.