### PR TITLE
disable pre-release publishing

### DIFF
--- a/.github/workflows/publish-omnikdatalogger.yml
+++ b/.github/workflows/publish-omnikdatalogger.yml
@@ -1,11 +1,11 @@
-# This workflow will upload a Python Package using Twine when a release is created
+# This workflow will upload a Python Package using Twine when a new version is released (pre-releases are excluded)
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Upload Python Package omnikdatalogger
 
 on:
   release:
-    types: [created]
+    types: [released]
     branches:
       - main
 

--- a/apps/omnikdatalogger/omnik/__init__.py
+++ b/apps/omnikdatalogger/omnik/__init__.py
@@ -8,7 +8,7 @@ import threading
 
 logging.basicConfig(stream=sys.stdout, level=os.environ.get("LOGLEVEL", logging.INFO))
 
-__version__ = "1.9.0"
+__version__ = "1.10.0-beta-2"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
The current git-hub action that publishes to docker and pip has been changed to only publish on releases. HACS users can still use the pre-releases. Other users can use the zip files.