### PR TITLE
Update value template filter for MQTT timestamp sensors

### DIFF
--- a/apps/omnikdatalogger/data_fields.json
+++ b/apps/omnikdatalogger/data_fields.json
@@ -40,7 +40,7 @@
         "unit": "",
         "measurement": null,
         "tags": {},
-        "filter": "|timestamp_local",
+        "filter": "|as_datetime",
         "asset": "omnik"
     },
     "inverter_temperature": {
@@ -70,7 +70,7 @@
         "unit": "",
         "measurement": null,
         "tags": { "source": "openweather.org" },
-        "filter": "|timestamp_local",
+        "filter": "|as_datetime",
         "asset": "openweather"
     },
     "current_ac1": {
@@ -387,7 +387,7 @@
         "unit": "",
         "measurement": null,
         "tags": {},
-        "filter": "|timestamp_local",
+        "filter": "|as_datetime",
         "asset": "dsmr_gas"
     },
     "gas_consumption_total": {
@@ -417,7 +417,7 @@
         "unit": "",
         "measurement": null,
         "tags": {},
-        "filter": "|timestamp_local",
+        "filter": "|as_datetime",
         "asset": "dsmr"
     },
     "ELECTRICITY_USED_TARIFF_1": {
@@ -873,7 +873,7 @@
         "unit": "",
         "measurement": null,
         "tags": {},
-        "filter": "|timestamp_local",
+        "filter": "|as_datetime",
         "asset": "omnik_dsmr"
     },
     "energy_used": {


### PR DESCRIPTION
From Home Assistant 2021.12.0 sensors with `device_class` == `timestamp` need be be assigned a native `datetime` type. The current implementation uses string formatted timestamps. But this will give warnings in the log.

This PR changes the `value_template` for the MQTT `timestamp` sensors of omnikdatalogger.
The current filter `|timestamp_local` will be replaced with `|as_datetime`. The `as_datetime` filter will only allow time formatted strings with the current release of Home Assistant. The Home Assistant PR https://github.com/home-assistant/core/pull/60126 will add a UNIX timestamp filter to allow a direct conversion to datetime.
For the PR to be merged it is needed that this new functionality of the `as_datetime` filter also comes available in Home Assistant 2021.12.0.