### PR TITLE
Improve tcpclient logging and fallback - v1.10.3

### DIFF
--- a/apps/omnikdatalogger/omnik/__init__.py
+++ b/apps/omnikdatalogger/omnik/__init__.py
@@ -8,7 +8,7 @@ import threading
 
 logging.basicConfig(stream=sys.stdout, level=os.environ.get("LOGLEVEL", logging.INFO))
 
-__version__ = "1.10.2"
+__version__ = "1.10.3"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Improve the logging for `tcpclient`.
If an inverter only supports 'http' a warning will be shown if the `http_only` parameter is not set. Omnikdatalogger will keep trying to connect over port 8899.