### PR TITLE
Always send generated energy data to pvoutput when using DSMR

### DIFF
--- a/apps/omnikdatalogger/omnik/__init__.py
+++ b/apps/omnikdatalogger/omnik/__init__.py
@@ -8,7 +8,7 @@ import threading
 
 logging.basicConfig(stream=sys.stdout, level=os.environ.get("LOGLEVEL", logging.INFO))
 
-__version__ = "1.10.3"
+__version__ = "1.10.4"
 
 logger = logging.getLogger(__name__)
 

--- a/apps/omnikdatalogger/omnik/datalogger.py
+++ b/apps/omnikdatalogger/omnik/datalogger.py
@@ -1048,7 +1048,7 @@ class DataLogger(object):
             self.cache[last_current_power] = Decimal("0.0")
             self.cache[last_reset] = str(last_reset_payload)
             if self.cache.get(last_total_energy):
-                # reset start energy in memory now today energy is reset
+                # reset initial energy in memory since today_energy is reset
                 self.start_total_energy[plant] = self.cache.get(last_total_energy)
             self._update_persistant_cache()
             return self.cache[last_today_energy]
@@ -1139,6 +1139,8 @@ class DataLogger(object):
                 cached_data["today_energy"] = self.total_energy(
                     plant_id, lifetime=False
                 )
+                # Assume we have no solar power currently
+                cached_data["current_power"] = Decimal("0.0")
                 self._aggregate_data(aggegated_data, cached_data)
                 cached_last_update = self.get_last_update(plant_id, 0.0)
                 if cached_last_update > last_solar_update:
@@ -1146,8 +1148,6 @@ class DataLogger(object):
 
             if aggegated_data:
                 aggegated_data.update(data)
-            # Do not publish the current power, since we do not know the last state
-            # set next time block for update
             self.pasttime = (
                 dsmr_timestamp
                 - (dsmr_timestamp % self.interval_aggregated)

--- a/apps/omnikdatalogger/omnik/plugin_output/pvoutput.py
+++ b/apps/omnikdatalogger/omnik/plugin_output/pvoutput.py
@@ -8,6 +8,7 @@ from omnik.plugin_output import Plugin
 from decimal import Decimal
 import threading
 
+
 class pvoutput(Plugin):
     def __init__(self):
         super().__init__()
@@ -127,11 +128,11 @@ class pvoutput(Plugin):
                 # v4 = bruto power_consumption (W)
                 # c1 = 1 ; v3 is cumulative so the c1 flag is set
                 # see note about Cumulative Enery at https://pvoutput.org/help.html#api-addstatus
-            if "current_power" in msg:
+            if "today_energy" in msg:
                 data.update(
                     {
                         "v1": f"{msg['today_energy'] * Decimal('1000')}",
-                        "v2": f"{msg['current_power']}",
+                        "v2": f"{msg.get('current_power') or 0}",
                     }
                 )
                 # v1 = energy_generated (Wh) * 1000 ; this value is on a daily basis


### PR DESCRIPTION
When pvoutput is used with DSMR it keeps sending consumption data but stops sending energy generation data.
This may cause strange effects in the pvoutput graphs.
This PR will keep sending out the energy generation data from cache after the sun has gone.
At midnight the daily energy parameter will be reset.

This PR also updates the version to 1.10.4