### PR TITLE
Fix duplicate logging pvoutput

### DIFF
--- a/apps/omnikdatalogger/omnik/datalogger.py
+++ b/apps/omnikdatalogger/omnik/datalogger.py
@@ -1133,6 +1133,7 @@ class DataLogger(object):
                     cached_last_update = self.get_last_update(plant, 0.0)
                     if cached_last_update > last_solar_update:
                         last_solar_update = cached_last_update
+                aggegated_data.update(data)
             elif self.total_energy(plant_id):
                 cached_data = {}
                 cached_data["plant_id"] = plant_id
@@ -1147,9 +1148,6 @@ class DataLogger(object):
                 cached_last_update = self.get_last_update(plant_id, 0.0)
                 if cached_last_update > last_solar_update:
                     last_solar_update = cached_last_update
-
-            if aggegated_data:
-                aggegated_data.update(data)
 
             self.pasttime = (
                 dsmr_timestamp
@@ -1172,14 +1170,16 @@ class DataLogger(object):
                     self.plant_update[plant_id].last_update_time
                 )
             # we will send (net) updates when inverers do not retreive new updates
-            if aggegated_data and (dsmr_timestamp - last_update) > self.every:
+            if (dsmr_timestamp - last_update) > self.every:
+                if aggegated_data:
+                    data.update(aggegated_data)
+                else:
+                    data.update(cached_data)
+                # calculate energy_use
+                self._calculate_consumption(data)
                 self._process_received_update(
-                    aggegated_data, netdata=True, plant=plant_id
+                    data, netdata=True, plant=plant_id
                 )
-                # Add omnik specific data for self._output_update to dataset
-                self._calculate_consumption(aggegated_data)
-                # Export combined to pvoutput
-                self._output_update_aggregated_data(plant_id, aggegated_data)
                 target = f"for plant {plant_id} " if plant_id else ""
                 hybridlogger.ha_log(
                     self.logger,
@@ -1187,12 +1187,8 @@ class DataLogger(object):
                     "DEBUG",
                     f"Combining cached logging {target} with DSRM data.",
                 )
-                # use last solar update time stamp for real time data output (not a dsmr_time stamp)
-                data.update(aggegated_data)
-                data["last_update"] = (
-                    last_solar_update if last_solar_update else dsmr_timestamp
-                )
-        # TODO process net update for other clients
+                # update the output for aggregated logging
+        # process net update for other clients
         self._output_update(plant_id, data)
 
     def _process_timed_event(self):


### PR DESCRIPTION
When the sub is down and DSMR is used with pvoutput two updates are pushed, and with an incorrect timestamp