### PR TITLE
last_update not as base for pvoutput for netdata

### DIFF
--- a/apps/omnikdatalogger/omnik/__init__.py
+++ b/apps/omnikdatalogger/omnik/__init__.py
@@ -8,7 +8,7 @@ import threading
 
 logging.basicConfig(stream=sys.stdout, level=os.environ.get("LOGLEVEL", logging.INFO))
 
-__version__ = "1.10.4"
+__version__ = "1.10.5"
 
 logger = logging.getLogger(__name__)
 

--- a/apps/omnikdatalogger/omnik/plugin_output/pvoutput.py
+++ b/apps/omnikdatalogger/omnik/plugin_output/pvoutput.py
@@ -88,8 +88,11 @@ class pvoutput(Plugin):
                     "ignoring publishing to pvoutput, no sys_id was set",
                 )
                 return
-            reporttime = time.localtime(msg["last_update"])
-
+            # Always use current time for net updates
+            if msg.get("net_update"):
+                reporttime = time.localtime(time.time())
+            else:
+                reporttime = time.localtime(msg["last_update"])
             # self.logger.debug(json.dumps(msg, indent=2))
             if not self._check_requirements(msg):
                 return


### PR DESCRIPTION
field last_update holds the last update from the solar data. This fiels should not be used when updating pvoutput if the solar data is cached.