### PR TITLE
Add InfluxDB2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,15 +215,27 @@ omnik_datalogger:
     username: john.doe@example.com
     password: some_password
 
-  # Influxdb output plugin configuration options
+ # Influxdb output plugin configuration options
   output.influxdb:
+    # Common settings
     host: localhost
     port: 8086
+    ssl: false #  # Use SSL
+    verify_ssl: true # Verify SSL certificate for HTTPS request
+
+    use_temperature: true # If true logs the temperature of the openweathermap API
+
+    # InfluxDB v1 only
     database: omnikdatalogger
     username: omnikdatalogger
     password: mysecretpassword
     #jwt_token=
-    use_temperature: true
+
+    # InfluxDB v2 only
+    org: jbsoft
+    bucket: omnik
+    token: generatedtoken
+    ssl_ca_cert: path_to_custom_ca.crt # Only for InfluxDB 2!
 
   # csvoutput output plugin configuration options
   output.csvoutput:
@@ -661,13 +673,19 @@ The following additional fields are available if DSMR data can be matched with t
 | ----------------- | -------- | ------- | ----------------- | ---------------------------------------------------------------------------- |
 | `host`            | True     | string  | `localhost`       | Hostname or fqdn of the InfluxDB server for logging.                         |
 | `port`            | True     | integer | `8086`            | InfluxDB port to be used.                                                    |
-| `database`        | True     | string  | _omnikdatalogger_ | The InfluxDB database                                                        |
-| `username`        | True     | string  | _(none)_          | The InfluxDB username used for Basic authentication                          |
-| `password`        | True     | string  | _(none)_          | The InfluxDB password used for Basic authentication                          |
-| `jwt_token`       | True     | string  | _(none)_          | The InfluxDB webtoken for JSON Web Token authentication                      |
+| `ssl`             | True     | bool    | `false`           | Use SSL. Set to `true` if the URL starts with `https://`                     |
+| `verify_ssl`      | True     | bool    | `true`            | By default a certificate is validated. Set to `false` to disable validation. |
+| `org`             | True     | string  | _(none)_          | The InfluxDB2 organisation (InfluxDB 2.x only)                               |
+| `bucket`          | True     | string  | _(none)_          | The InfluxDB2 bucket to write to (InfluxDB 2.x only)                         |
+| `token`           | True     | string  | _(none)_          | The InfluxDB2 authentication token (InfluxDB 2.x only)                       |
 | `use_temperature` | True     | bool    | `false`           | When set to true the temperature is obtained from OpenWeatherMap and logged. |
+| `database`        | True     | string  | _omnikdatalogger_ | The InfluxDB database (InfluxDB 1.8x only)                                   |
+| `username`        | True     | string  | _(none)_          | The InfluxDB username used for Basic authentication (InfluxDB 1.8x only)     |
+| `password`        | True     | string  | _(none)_          | The InfluxDB password used for Basic authentication (InfluxDB 1.8x only)     |
+| `jwt_token`       | True     | string  | _(none)_          | The InfluxDB webtoken for JSON Web Token authentication (InfluxDB 1.8x only) |
 
 Logging to InfluxDB is supported with configuration settings from `data_fields.json` The file allows to customize measurement header and allows setting additional tags.
+When using InfluxDB2, authentication is mandantory. Configure `org`, `bucket` and `token` to enable the InfluxDB v2 client.
 
 #### OpenWeatherMap settings in the section `openweathermap` of `apps.yaml` or `config.yaml`
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ omnik_datalogger:
     username: john.doe@example.com
     password: some_password
 
- # Influxdb output plugin configuration options
+  # Influxdb output plugin configuration options
   output.influxdb:
     # Common settings
     host: localhost
@@ -675,6 +675,7 @@ The following additional fields are available if DSMR data can be matched with t
 | `port`            | True     | integer | `8086`            | InfluxDB port to be used.                                                    |
 | `ssl`             | True     | bool    | `false`           | Use SSL. Set to `true` if the URL starts with `https://`                     |
 | `verify_ssl`      | True     | bool    | `true`            | By default a certificate is validated. Set to `false` to disable validation. |
+| `ssl_ca_cert`     | True     | string  | _(none)_          | Set an alternative CA cert. (InfluxDB 2.x client only)                       |
 | `org`             | True     | string  | _(none)_          | The InfluxDB2 organisation (InfluxDB 2.x only)                               |
 | `bucket`          | True     | string  | _(none)_          | The InfluxDB2 bucket to write to (InfluxDB 2.x only)                         |
 | `token`           | True     | string  | _(none)_          | The InfluxDB2 authentication token (InfluxDB 2.x only)                       |

--- a/apps/omnikdatalogger/omnik/__init__.py
+++ b/apps/omnikdatalogger/omnik/__init__.py
@@ -8,7 +8,7 @@ import threading
 
 logging.basicConfig(stream=sys.stdout, level=os.environ.get("LOGLEVEL", logging.INFO))
 
-__version__ = "1.10.5"
+__version__ = "1.11.0"
 
 logger = logging.getLogger(__name__)
 

--- a/apps/omnikdatalogger/omnik/datalogger.py
+++ b/apps/omnikdatalogger/omnik/datalogger.py
@@ -800,7 +800,9 @@ class DataLogger(object):
         if not data:
             return
         # Check for pvoutput sys_id override in config
-        sys_id = int(self.config.get(f"plant.{data['plant_id']}", "sys_id", "0"))
+        sys_id = int(
+            self.config.get(f"plant.{data.get('plant_id','0')}", "sys_id", "0")
+        )
         global_sys_id = int(self.config.get("output.pvoutput", "sys_id", "0"))
         if sys_id and (sys_id != global_sys_id):
             # Do no aggegate: add sys_id to data set

--- a/apps/omnikdatalogger/omnik/plugin_output/__init__.py
+++ b/apps/omnikdatalogger/omnik/plugin_output/__init__.py
@@ -26,7 +26,7 @@ class Plugin(object, metaclass=BasePlugin):
     process_aggregates = False
     process_output = False
     name = "plugin_output"
-    description = "Parent class for autout plugins"
+    description = "Parent class for output plugins"
 
     cache = TTLCache(maxsize=1, ttl=300)
 

--- a/info.md
+++ b/info.md
@@ -141,13 +141,25 @@ omnik_datalogger:
 
   # Influxdb output plugin configuration options
   output.influxdb:
+    # Common settings
     host: localhost
     port: 8086
+    ssl: false #  # Use SSL
+    verify_ssl: true # Verify SSL certificate for HTTPS request
+
+    use_temperature: true # If true logs the temperature of the openweathermap API
+
+    # InfluxDB v1 only
     database: omnikdatalogger
     username: omnikdatalogger
     password: mysecretpassword
     #jwt_token=
-    use_temperature: true
+
+    # InfluxDB v2 only
+    org: jbsoft
+    bucket: omnik
+    token: generatedtoken
+    ssl_ca_cert: path_to_custom_ca.crt # Only for InfluxDB 2!
 
   # csvoutput output plugin configuration options
   output.csvoutput:
@@ -565,13 +577,19 @@ The following additional fields are available if DSMR data can be matched with t
 | ----------------- | -------- | ------- | ----------------- | ---------------------------------------------------------------------------- |
 | `host`            | True     | string  | `localhost`       | Hostname or fqdn of the InfluxDB server for logging.                         |
 | `port`            | True     | integer | `8086`            | InfluxDB port to be used.                                                    |
-| `database`        | True     | string  | _omnikdatalogger_ | The InfluxDB database                                                        |
-| `username`        | True     | string  | _(none)_          | The InfluxDB username used for Basic authentication                          |
-| `password`        | True     | string  | _(none)_          | The InfluxDB password used for Basic authentication                          |
-| `jwt_token`       | True     | string  | _(none)_          | The InfluxDB webtoken for JSON Web Token authentication                      |
+| `ssl`             | True     | bool    | `false`           | Use SSL. Set to `true` if the URL starts with `https://`                     |
+| `verify_ssl`      | True     | bool    | `true`            | By default a certificate is validated. Set to `false` to disable validation. |
+| `org`             | True     | string  | _(none)_          | The InfluxDB2 organisation (InfluxDB 2.x only)                               |
+| `bucket`          | True     | string  | _(none)_          | The InfluxDB2 bucket to write to (InfluxDB 2.x only)                         |
+| `token`           | True     | string  | _(none)_          | The InfluxDB2 authentication token (InfluxDB 2.x only)                       |
 | `use_temperature` | True     | bool    | `false`           | When set to true the temperature is obtained from OpenWeatherMap and logged. |
+| `database`        | True     | string  | _omnikdatalogger_ | The InfluxDB database (InfluxDB 1.8x only)                                   |
+| `username`        | True     | string  | _(none)_          | The InfluxDB username used for Basic authentication (InfluxDB 1.8x only)     |
+| `password`        | True     | string  | _(none)_          | The InfluxDB password used for Basic authentication (InfluxDB 1.8x only)     |
+| `jwt_token`       | True     | string  | _(none)_          | The InfluxDB webtoken for JSON Web Token authentication (InfluxDB 1.8x only) |
 
 Logging to InfluxDB is supported with configuration settings from `data_fields.json` The file allows to customize measurement header and allows setting additional tags.
+When using InfluxDB2, authentication is mandantory. Configure `org`, `bucket` and `token` to enable the InfluxDB v2 client.
 
 ##### OpenWeatherMap settings in the section `openweathermap` of `apps.yaml`
 

--- a/info.md
+++ b/info.md
@@ -579,6 +579,7 @@ The following additional fields are available if DSMR data can be matched with t
 | `port`            | True     | integer | `8086`            | InfluxDB port to be used.                                                    |
 | `ssl`             | True     | bool    | `false`           | Use SSL. Set to `true` if the URL starts with `https://`                     |
 | `verify_ssl`      | True     | bool    | `true`            | By default a certificate is validated. Set to `false` to disable validation. |
+| `ssl_ca_cert`     | True     | string  | _(none)_          | Set an alternative CA cert. (InfluxDB 2.x client only)                       |
 | `org`             | True     | string  | _(none)_          | The InfluxDB2 organisation (InfluxDB 2.x only)                               |
 | `bucket`          | True     | string  | _(none)_          | The InfluxDB2 bucket to write to (InfluxDB 2.x only)                         |
 | `token`           | True     | string  | _(none)_          | The InfluxDB2 authentication token (InfluxDB 2.x only)                       |

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ paho-mqtt>=1.5.0
 dsmr-parser>=0.21
 astral>=1.10.1
 pyyaml>=5.1
+influxdb-client>=1.26

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@ def get_version(package):
     """
     Return package version as listed in `__version__` in `__init__.py`.
     """
-    path = os.path.join(os.path.dirname(__file__), package, '__init__.py')
-    with open(path, 'rb') as f:
-        init_py = f.read().decode('utf-8')
+    path = os.path.join(os.path.dirname(__file__), package, "__init__.py")
+    with open(path, "rb") as f:
+        init_py = f.read().decode("utf-8")
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
 
@@ -17,19 +17,20 @@ with open("README.md", "r", encoding="UTF-8") as fh:
     long_description = fh.read()
 
 install_requires = [
-    'configparser>=3.7.4',
-    'requests>=2.21.0',
-    'cachetools>=3.1.1',
-    'pytz>=2019.1',
-    'paho-mqtt>=1.5.0',
-    'dsmr-parser>=0.21',
-    'astral>=1.10.1',
-    'pyyaml>=5.1',
+    "configparser>=3.7.4",
+    "requests>=2.21.0",
+    "cachetools>=3.1.1",
+    "pytz>=2019.1",
+    "paho-mqtt>=1.5.0",
+    "dsmr-parser>=0.21",
+    "astral>=1.10.1",
+    "pyyaml>=5.1",
+    "influxdb-client>=1.36",
 ]
 
 setup(
     name="omnikdatalogger",
-    version=get_version('apps/omnikdatalogger/omnik'),
+    version=get_version("apps/omnikdatalogger/omnik"),
     license="gpl-3.0",
     author="Jan Bouwhuis",
     author_email="jan@jbsoft.nl",
@@ -39,18 +40,22 @@ setup(
     url="https://github.com/jbouwh/omnikdatalogger",
     package_dir={"": "apps/omnikdatalogger"},
     packages=find_packages(where="apps/omnikdatalogger"),
-    data_files=[('share/omnikdatalogger', [
-        'apps/omnikdatalogger/data_fields.json',
-        'scripts/systemd/omnikdatalogger.service',
-        ])
-                ],
+    data_files=[
+        (
+            "share/omnikdatalogger",
+            [
+                "apps/omnikdatalogger/data_fields.json",
+                "scripts/systemd/omnikdatalogger.service",
+            ],
+        )
+    ],
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Topic :: Home Automation',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 5 - Production/Stable",
+        "Topic :: Home Automation",
+        "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Operating System :: OS Independent"
+        "Operating System :: OS Independent",
     ],
     install_requires=install_requires,
-    scripts=['apps/omnikdatalogger/omniklogger.py'],
+    scripts=["apps/omnikdatalogger/omniklogger.py"],
 )


### PR DESCRIPTION
Adds native InfluxDB 2.0 support.

Configure `org`, `bucket` and `token` to use the new InfluxDB v2 client. The update will not break older v1.8.x configurations.

### New InfluxDB plugin settings in the section `output.influxdb` in of `apps.yaml` or `config.yaml`

| key               | optional | type    | default           | description                                                                  |
| ----------------- | -------- | ------- | ----------------- | ---------------------------------------------------------------------------- |
| `ssl`             | True     | bool    | `false`           | Use SSL. Set to `true` if the URL starts with `https://`                     |
| `verify_ssl`      | True     | bool    | `true`            | By default a certificate is validated. Set to `false` to disable validation. |
| `ssl_ca_cert`     | True     | string  | _(none)_          | Set an alternative CA cert. (InfluxDB 2.x client only)                       |
| `org`             | True     | string  | _(none)_          | The InfluxDB2 organisation (InfluxDB 2.x only)                               |
| `bucket`          | True     | string  | _(none)_          | The InfluxDB2 bucket to write to (InfluxDB 2.x only)                         |
| `token`           | True     | string  | _(none)_          | The InfluxDB2 authentication token (InfluxDB 2.x only)                       |
