### PR TITLE
daylight: Use proper timezone instead of interpreting UTC as local time

### DIFF
--- a/apps/omnikdatalogger/omnik/daylight.py
+++ b/apps/omnikdatalogger/omnik/daylight.py
@@ -25,7 +25,8 @@ class daylight(object):
             self._a = Astral()
             self._a.solar_depression = "civil"
             self._city = self._a[city_name]
-            self._timezone = pytz.timezone(self._city.timezone)
+
+        self._timezone = pytz.timezone(self._city.timezone)
 
     def sun(self, t=None):
         if not t:
@@ -36,7 +37,7 @@ class daylight(object):
             return self._city.sun(t)
 
     def localtime(self):
-        return datetime.utcnow().astimezone(pytz.timezone(self._city.timezone))
+        return datetime.now(self._timezone)
 
     @property
     def version(self):


### PR DESCRIPTION
Fixes #72, CC @fritzzjan

Both [`datetime.now()`] and [`datetime.utcnow()`] return a `datetime` object _without_ `tzinfo`.  As such `.astimezone()` has no reference timezone to convert from when applying the desired timezone, and assumes the `datetime` object to be in local time.  In this instance `.astimezone()` assumes the result from `.utcnow()` to be in local time, hence performs no conversion (in the case where `city` matches the local timezone) leading to `localtime()` returning unmodified UTC time disguised as a different timezone.

For this reason the documentation on [`datetime.utcnow()`] recommends to use [`datetime.now()`] with an explicit timezone argument like `timezone.utc` or in the case of this PR, the desired timezone directly.

[`datetime.now()`]: https://docs.python.org/3/library/datetime.html#datetime.datetime.now
[`datetime.utcnow()`]: https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow
