### PR TITLE
Close socket to DSRM tcp if no data is served

### DIFF
--- a/apps/omnikdatalogger/omnik/__init__.py
+++ b/apps/omnikdatalogger/omnik/__init__.py
@@ -11,7 +11,7 @@ from omnik.ha_logger import hybridlogger
 
 logging.basicConfig(stream=sys.stdout, level=os.environ.get("LOGLEVEL", logging.INFO))
 
-__version__ = "1.14.3"
+__version__ = "1.14.4"
 
 logger = logging.getLogger(__name__)
 

--- a/apps/omnikdatalogger/omnik/dsmr/terminal.py
+++ b/apps/omnikdatalogger/omnik/dsmr/terminal.py
@@ -139,7 +139,8 @@ class Terminal(object):
                             "INFO",
                             f"DSMR terminal {self.terminal_name} was interrupted and will be restarted.",
                         )
-                        time.sleep(5)
+                        self.sock.close()
+                        time.sleep(20)
                         break
                     elif data:
                         self._dsmr_data_received(data)


### PR DESCRIPTION
Fix: When the DSMR session was disturbed, the socket was not closed.
Bump to 1.14.4